### PR TITLE
Android 4.0以降におけるKeyStore関連の変更への対応

### DIFF
--- a/src/net/shirayu/android/WlanLogin/MyHttpClient.java
+++ b/src/net/shirayu/android/WlanLogin/MyHttpClient.java
@@ -49,6 +49,7 @@ import org.apache.http.protocol.HttpContext;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.PreferenceManager;
 
 
@@ -230,8 +231,15 @@ implements HttpClient,
 				http://wiki.livedoor.jp/syo1976/d/javassl
 				http://d.hatena.ne.jp/Kazzz/20110319/p1
 			 */
-		  	KeyStore certstore = KeyStore.getInstance(KeyStore.getDefaultType());
-			certstore.load(new FileInputStream(System.getProperty("javax.net.ssl.trustStore")), null); //load default keystore
+			KeyStore certstore;
+			if (Integer.valueOf(Build.VERSION.SDK) >= 14) {
+				// load from unified key store
+				certstore = KeyStore.getInstance("AndroidCAStore");
+				certstore.load(null, null);
+			} else {
+				certstore =  KeyStore.getInstance(KeyStore.getDefaultType());
+				certstore.load(new FileInputStream(System.getProperty("javax.net.ssl.trustStore")), null); //load default keystore
+			}
 
 			//load self_signed_certificate?
 			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);


### PR DESCRIPTION
WlanLoginをAndroid 4.0以降で動作させるためのPull requestです．
### 問題

Android 4.0(API 14)以降では，ルート証明書の管理方法が変更になりました．

http://blog.livedoor.jp/k_urushima/archives/1687963.html
http://nelenkov.blogspot.jp/2011/11/using-ics-keychain-api.html

これに伴い，Android 4.0以降の端末において自動認証に失敗する問題が発生していました．
具体的には，src/net/shirayu/android/WlanLogin/MyHttpClient.javaの234行目においてNullPointerExceptionが発生します．
### 対処

tomwhipple/AndroidPinning@03d9b7d27ae3b12a946f7ac76143b7213af67579 を参考に，Android 4.0以降用のKeyStoreを使用するよう変更しました．

手元のGalaxy Note SC-05D(Android 4.0.4)では正常に動作しているようです．
